### PR TITLE
Add compatibility with the homee WeMo integration

### DIFF
--- a/lib/emulate.js
+++ b/lib/emulate.js
@@ -186,6 +186,31 @@ EmulatedDevice.prototype._endpoints = {
         res.end();
     }
 
+    , '/eventservice.xml': function(req, res) {
+        res.writeHead(200);
+
+            var xml = XML({
+              scpd: {
+                '@xmlns': SETUP_XMLNS
+                , specVersion: {
+                    major: 1
+                  , minor: 0
+              },
+              actionList: [
+                {action: {
+                    name: 'GetBinaryState'
+                  }}
+                , {action: {
+                    name: 'SetBinaryState'
+                  }}
+              ]
+            }
+          });
+
+        res.write(xml);
+        res.end();
+    }
+
   , '/upnp/control/basicevent1': function(req, res) {
         var self = this
           , buffer = '';

--- a/lib/emulate.js
+++ b/lib/emulate.js
@@ -244,6 +244,18 @@ EmulatedDevice.prototype._endpoints = {
 
                 self.emit('state', self.binaryState, self);
                 res.writeHead(200);
+                res.write(XML({
+                    's:Envelope': {
+                        '@xmlns:s': 'http://schemas.xmlsoap.org/soap/envelope/'
+                            , '@s:encodingStyle': 'http://schemas.xmlsoap.org/soap/encoding/'
+                            , 's:Body': {
+                                'u:SetBinaryStateResponse': {
+                                    '@xmlns:u': 'urn:Belkin:service:basicevent:1'
+                                        , BinaryState: self.binaryState
+                                }
+                            }
+                    }
+                }));
                 res.end();
 
             } else {

--- a/lib/emulate.js
+++ b/lib/emulate.js
@@ -226,7 +226,7 @@ EmulatedDevice.prototype._endpoints = {
                             , 's:Body': {
                                 'u:GetBinaryStateResponse': {
                                     '@xmlns:u': 'urn:Belkin:service:basicevent:1'
-                                        , BinaryState: this.binaryState
+                                        , BinaryState: self.binaryState
                                 }
                             }
                     }


### PR DESCRIPTION
Thanks for the great lib!

This PR adds compatibility with the homee smart home hubs WeMo integration.

It changes 3 things:

* homee get's the devices capabilities from the event service.xml
* Fix the initial binary state being undefined
* Add a response to a set binary request so the smart home hub knows it worked and shows the correct state