### PR TITLE
Fix finding only one emulated device in network

### DIFF
--- a/lib/emulate.js
+++ b/lib/emulate.js
@@ -186,6 +186,31 @@ EmulatedDevice.prototype._endpoints = {
         res.end();
     }
 
+    , '/eventservice.xml': function(req, res) {
+        res.writeHead(200);
+
+            var xml = XML({
+              scpd: {
+                '@xmlns': SETUP_XMLNS
+                , specVersion: {
+                    major: 1
+                  , minor: 0
+              },
+              actionList: [
+                {action: {
+                    name: 'GetBinaryState'
+                  }}
+                , {action: {
+                    name: 'SetBinaryState'
+                  }}
+              ]
+            }
+          });
+
+        res.write(xml);
+        res.end();
+    }
+
   , '/upnp/control/basicevent1': function(req, res) {
         var self = this
           , buffer = '';

--- a/lib/emulate.js
+++ b/lib/emulate.js
@@ -113,6 +113,7 @@ EmulatedDevice.prototype._initSsdp = function() {
       , logLevel: this.logLevel
       , location: 'http://' + this.host + ':' + this.port + '/setup.xml'
       , ttl: 86400
+      , udn: 'uuid:' + uuid.v4()
     }, SERVER.sock);
     this.ssdp.addUSN(BELKIN_CONTROLLEE);
     this.ssdp.addUSN(BELKIN_BASICEVENT);

--- a/lib/emulate.js
+++ b/lib/emulate.js
@@ -244,6 +244,18 @@ EmulatedDevice.prototype._endpoints = {
 
                 self.emit('state', self.binaryState, self);
                 res.writeHead(200);
+                res.write(XML({
+                    's:Envelope': {
+                        '@xmlns:s': 'http://schemas.xmlsoap.org/soap/envelope/'
+                            , '@s:encodingStyle': 'http://schemas.xmlsoap.org/soap/encoding/'
+                            , 's:Body': {
+                                'u:SetBinaryStateResponse': {
+                                    '@xmlns:u': 'urn:Belkin:service:basicevent:1'
+                                        , BinaryState: self.binaryState
+                                }
+                            }
+                    }
+                }));
                 res.end();
 
             } else {

--- a/lib/emulate.js
+++ b/lib/emulate.js
@@ -226,7 +226,7 @@ EmulatedDevice.prototype._endpoints = {
                             , 's:Body': {
                                 'u:GetBinaryStateResponse': {
                                     '@xmlns:u': 'urn:Belkin:service:basicevent:1'
-                                        , BinaryState: this.binaryState
+                                        , BinaryState: self.binaryState
                                 }
                             }
                     }


### PR DESCRIPTION
The unique usn of the ssdp server is used by some apps to identify devices. Without initializing it, a default usn (always the same) is used. So the app will always find only one device in the network.

I'm note sure using the uuid.v4() function ist the best way here, but with this is unique at least.