### PR TITLE
changed identification param to uuid

### DIFF
--- a/lib/emulate.js
+++ b/lib/emulate.js
@@ -113,7 +113,7 @@ EmulatedDevice.prototype._initSsdp = function() {
       , logLevel: this.logLevel
       , location: 'http://' + this.host + ':' + this.port + '/setup.xml'
       , ttl: 86400
-      , udn: 'uuid:' + this.serial
+      , udn: 'uuid:' + this.uuid
     }, SERVER.sock);
     this.ssdp.addUSN(BELKIN_CONTROLLEE);
     this.ssdp.addUSN(BELKIN_BASICEVENT);

--- a/lib/emulate.js
+++ b/lib/emulate.js
@@ -113,7 +113,7 @@ EmulatedDevice.prototype._initSsdp = function() {
       , logLevel: this.logLevel
       , location: 'http://' + this.host + ':' + this.port + '/setup.xml'
       , ttl: 86400
-      , udn: 'uuid:' + uuid.v4()
+      , udn: 'uuid:' + this.serial
     }, SERVER.sock);
     this.ssdp.addUSN(BELKIN_CONTROLLEE);
     this.ssdp.addUSN(BELKIN_BASICEVENT);
@@ -129,7 +129,7 @@ EmulatedDevice.prototype._onHttpRequest = function(req, res) {
     var handler = this._endpoints[req.url];
     if (!handler) {
         if (this.logLevel) {
-            console.log('404', this.friendlyName, 
+            console.log('404', this.friendlyName,
                 "<<", req.method, req.url);
         }
         res.writeHead(404);
@@ -163,7 +163,7 @@ EmulatedDevice.prototype._endpoints = {
                   // now some BS stuff so others will accept us
                   , manufacturer: "Belkin International Inc." // req
                   , manufacturerURL: "http://github.com/dhleong"
-                  , modelDescription: "Wemore Emulated Socket" 
+                  , modelDescription: "Wemore Emulated Socket"
                   , modelName: "Socket"
                   , modelNumber: 1.0
                   , modelURL: "http://github.com/dhleong/wemore"
@@ -241,7 +241,7 @@ EmulatedDevice.prototype._endpoints = {
                 res.end();
 
             } else if (body.SetBinaryState) {
-                self.binaryState = 
+                self.binaryState =
                     parseInt(body.SetBinaryState.BinaryState);
                 if (self.binaryState) {
                     self.emit('on', self);


### PR DESCRIPTION
In case of restarting the emulated device, the device udn changes. That means that the device is not longer detected by homee. The serial number is unique by default, but can also be specified. 